### PR TITLE
Feature1/notion

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
-// index.js (수정된 코드)
-require('dotenv').config(); // ✨ 이 줄이 반드시 가장 위에 있어야 합니다!
-
+require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
-const { getPages, createPage } = require('./services/notion');
 
-// 👇 환경 변수 로드 확인을 위한 console.log 추가
-console.log('--- 환경 변수 디버깅 시작 ---');
-console.log('NOTION_TOKEN (process.env):', process.env.NOTION_TOKEN ? '성공적으로 로드됨' : '로드 안 됨 또는 undefined');
-console.log('NOTION_DATABASE_ID (process.env):', process.env.NOTION_DATABASE_ID ? '성공적으로 로드됨' : '로드 안 됨 또는 undefined');
-console.log('--------------------------');
-// 👆 디버깅 라인 끝
+const {
+  createPage,
+  getPages,
+  getPagesSummary,
+  getPageDetails,
+  getPageTextAndLinksOnly
+} = require('./services/notion');
 
 const app = express();
 app.use(bodyParser.json());
 
+// ✅ 전체 페이지 조회 (최신순)
 app.get('/pages', async (req, res) => {
   try {
     const pages = await getPages();
@@ -25,12 +24,46 @@ app.get('/pages', async (req, res) => {
   }
 });
 
-app.post('/pages', async (req, res) => {
-  // tags가 아니라 description, eventDate, imageUrl이 누락되었을 수 있습니다.
-  // services/notion.js의 createPage 시그니처와 req.body가 일치하는지 확인하세요.
-  const { title, description, eventDate, imageUrl } = req.body; 
+// ✅ 페이지 요약 정보 조회
+app.get('/pages/summary', async (req, res) => {
   try {
-    const result = await createPage(title, description, eventDate, imageUrl); // 수정된 인자
+    const summaries = await getPagesSummary();
+    res.json(summaries);
+  } catch (error) {
+    console.error('요약 리스트 오류:', error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ✅ 단일 페이지 상세 정보
+app.get('/pages/:id', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const page = await getPageDetails(id);
+    res.json(page);
+  } catch (error) {
+    console.error('상세 페이지 오류:', error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ✅ 본문 텍스트 또는 하이퍼링크 URL만 추출
+app.get('/pages/:id/texts', async (req, res) => {
+  const { id } = req.params;
+  try {
+    const content = await getPageTextAndLinksOnly(id);
+    res.json(content);
+  } catch (error) {
+    console.error('텍스트/링크 추출 오류:', error.message);
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// ✅ 새 페이지 생성
+app.post('/pages', async (req, res) => {
+  const { title, description, eventDate, imageUrl } = req.body;
+  try {
+    const result = await createPage(title, description, eventDate, imageUrl);
     res.json(result);
   } catch (error) {
     console.error('페이지 생성 오류:', error.message);
@@ -39,5 +72,5 @@ app.post('/pages', async (req, res) => {
 });
 
 app.listen(3000, () => {
-  console.log('Server running on port 3000');
+  console.log('🚀 서버가 3000번 포트에서 실행 중입니다');
 });

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 const express = require('express');
 const bodyParser = require('body-parser');
 
+const cors = require('cors');
+
 const {
   createPage,
   getPages,
@@ -12,6 +14,22 @@ const {
 
 const app = express();
 app.use(bodyParser.json());
+
+const allowedOrigins = process.env.CORS_ORIGIN
+  ? process.env.CORS_ORIGIN.split(',').map(origin => origin.trim())
+  : [];
+
+app.use(cors({
+  origin: function(origin, callback) {
+    // origin이 undefined면(서버-서버 통신 등) 허용
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
+}));
 
 // ✅ 전체 페이지 조회 (최신순)
 app.get('/pages', async (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@notionhq/client": "^4.0.1",
+        "cors": "^2.8.5",
         "dotenv": "^17.2.0",
         "express": "^5.1.0"
       }
@@ -131,6 +132,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {
@@ -526,6 +540,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "@notionhq/client": "^4.0.1",
+    "cors": "^2.8.5",
     "dotenv": "^17.2.0",
     "express": "^5.1.0"
   }


### PR DESCRIPTION
📘 현재 지원되는 API 목록

1. 전체 페이지 조회
   - GET /pages
   - 최신순으로 10개의 전체 페이지 원본을 가져옵니다

2. 페이지 요약 정보 조회
   - GET /pages/summary
   - 각 페이지의 pageId, title, event_date만 추출한 요약 리스트를 반환합니다

3. 단일 페이지 상세 조회
   - GET /pages/:id
   - 특정 페이지의 상세 정보를 전체 구조로 가져옵니다

4. 본문 텍스트 또는 링크 추출
   - GET /pages/:id/texts
   - 해당 페이지의 본문에서 rich_text 블록 중 text와 link가 포함된 항목을 추출합니다
     예시: 
       { "text": "텍스트만 있는 경우" }
       { "url": "링크만 있는 경우" }
       { "text": "텍스트", "url": "https://링크주소" }

5. 새 페이지 생성
   - POST /pages
   - 제목, 설명, 날짜, 이미지 URL을 포함한 새 페이지를 생성합니다
   - 요청 body:
     {
       "title": "제목",
       "description": "설명",
       "eventDate": "2024-07-21",
       "imageUrl": "https://image.com"
     }